### PR TITLE
feat(kiarina-utils-file): prioritize file extension over content in MIME type detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **kiarina-utils-file**: **BREAKING** - Changed MIME type detection strategy to prioritize file extensions over content analysis
 - **kiarina-utils-file**: Improved `detect_mime_type()` API with `MimeDetectionOptions` TypedDict to reduce cognitive load
 
 ### Fixed

--- a/packages/kiarina-utils-file/CHANGELOG.md
+++ b/packages/kiarina-utils-file/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **BREAKING**: Changed MIME type detection strategy to prioritize file extensions over content analysis
+  - `detect_mime_type()` now prioritizes extension-based detection (custom dictionary → mimetypes) before falling back to content analysis (puremagic)
+  - **Philosophy**: File extensions represent explicit user intent and should be trusted
+  - **Rationale**: More intuitive behavior for applications - `.md` files are treated as Markdown even if content looks like plain text
+  - **Migration**: If your code relies on content-based detection taking precedence, you may need to adjust expectations
+  - Reordered function arguments: `file_name_hint` is now the first parameter (before `raw_data` and `stream`)
+  - Updated all docstrings and module documentation to reflect the new detection strategy
 - Improved `detect_mime_type()` API to reduce cognitive load
   - Introduced `MimeDetectionOptions` TypedDict to group optional parameters
   - Replaced multiple individual parameters with a single `options` parameter

--- a/packages/kiarina-utils-file/README.md
+++ b/packages/kiarina-utils-file/README.md
@@ -105,7 +105,7 @@ async def process_files():
     # All operations have async equivalents
     text = await kfa.read_text("large_file.txt")
     await kfa.write_json_dict("result.json", {"processed": True})
-    
+
     # FileBlob operations
     blob = await kfa.read_file("document.pdf")
     if blob:
@@ -118,11 +118,15 @@ async def process_files():
 import kiarina.utils.mime as km
 import kiarina.utils.ext as ke
 
-# MIME type detection from content and filename
+# MIME type detection - extension takes precedence
 mime_type = km.detect_mime_type(
+    file_name_hint="document.md",  # Extension is prioritized
     raw_data=file_data,
-    file_name_hint="document.pdf"
 )
+# Returns "text/markdown" even if content looks like plain text
+
+# Content-based detection (fallback when no extension)
+mime_type = km.detect_mime_type(raw_data=jpeg_data)  # "image/jpeg"
 
 # Extension detection from MIME type
 extension = ke.detect_extension("application/json")  # ".json"
@@ -249,7 +253,7 @@ All synchronous functions have async equivalents with the same signatures, but t
 ```python
 class FileBlob:
     def __init__(self, file_path, mime_blob=None, *, mime_type=None, raw_data=None, raw_text=None)
-    
+
     # Properties
     file_path: str
     mime_blob: MIMEBlob
@@ -261,7 +265,7 @@ class FileBlob:
     hash_string: str
     ext: str
     hashed_file_name: str
-    
+
     # Methods
     def is_binary() -> bool
     def is_text() -> bool
@@ -273,7 +277,7 @@ class FileBlob:
 ```python
 class MIMEBlob:
     def __init__(self, mime_type, raw_data=None, *, raw_text=None)
-    
+
     # Properties
     mime_type: str
     raw_data: bytes
@@ -283,7 +287,7 @@ class MIMEBlob:
     hash_string: str
     ext: str
     hashed_file_name: str
-    
+
     # Methods
     def is_binary() -> bool
     def is_text() -> bool
@@ -336,7 +340,7 @@ class MIMEBlob:
 ## Requirements
 
 - **Python**: 3.12 or higher
-- **Core dependencies**: 
+- **Core dependencies**:
   - `aiofiles>=24.1.0` - Async file operations
   - `charset-normalizer>=3.4.3` - Encoding detection
   - `filelock>=3.19.1` - File locking

--- a/packages/kiarina-utils-file/src/kiarina/utils/file/_core/operations/read_file.py
+++ b/packages/kiarina-utils-file/src/kiarina/utils/file/_core/operations/read_file.py
@@ -52,8 +52,8 @@ def read_file(
             return default
 
         mime_type = detect_mime_type(
-            raw_data=raw_data,
             file_name_hint=file_path,
+            raw_data=raw_data,
             default=fallback_mime_type,
         )
 

--- a/packages/kiarina-utils-file/src/kiarina/utils/mime/__init__.py
+++ b/packages/kiarina-utils-file/src/kiarina/utils/mime/__init__.py
@@ -2,33 +2,47 @@
 MIME type detection and processing utilities.
 
 This module provides comprehensive functionality for:
-- Detecting MIME types from binary data, file streams, and file names
+- Detecting MIME types from file names and binary data
 - Creating MIME-typed data containers (MIMEBlob)
 - Normalizing MIME types using configurable aliases
-- Multi-stage detection using content analysis and extension mapping
+- Multi-stage detection using extension mapping and content analysis
 
 Key Features:
-    - **Content-based detection**: Uses puremagic to analyze file headers and magic bytes
-    - **Extension-based detection**: Supports complex multi-part extensions (.tar.gz, .tar.gz.gpg)
+    - **Extension-based detection**: Prioritizes file extensions as explicit user intent
+    - **Content-based detection**: Uses puremagic as fallback for unknown extensions
+    - **Complex extensions**: Supports multi-part extensions (.tar.gz, .tar.gz.gpg)
     - **MIME type normalization**: Applies configurable aliases for consistency
     - **Data container**: MIMEBlob class for handling MIME-typed binary data
 
 Detection Strategy:
-    1. Content analysis using puremagic (most reliable)
-    2. Custom dictionary lookup for complex extensions
-    3. Standard library mimetypes fallback
-    4. Automatic MIME type alias normalization
+    1. Extension-based detection (prioritized):
+       - Custom dictionary lookup for complex extensions
+       - Standard library mimetypes for common extensions
+    2. Content analysis using puremagic (fallback)
+    3. Automatic MIME type alias normalization
+
+Philosophy:
+    File extensions represent explicit user intent and should be trusted.
+    Content analysis is used as a fallback when extension information is
+    unavailable or insufficient.
 
 Examples:
     >>> import kiarina.utils.mime as km
     >>>
-    >>> # Detect MIME type from binary data
+    >>> # Detect MIME type from file name (prioritized)
+    >>> mime_type = km.detect_mime_type(file_name_hint="document.md")
+    >>> print(mime_type)  # "text/markdown"
+    >>>
+    >>> # Detect from binary data (fallback)
     >>> mime_type = km.detect_mime_type(raw_data=jpeg_bytes)
     >>> print(mime_type)  # "image/jpeg"
     >>>
-    >>> # Detect from file name
-    >>> mime_type = km.detect_mime_type(file_name_hint="document.tar.gz")
-    >>> print(mime_type)  # "application/gzip"
+    >>> # Extension takes precedence
+    >>> mime_type = km.detect_mime_type(
+    ...     file_name_hint="document.md",
+    ...     raw_data=png_bytes  # Actually PNG
+    ... )
+    >>> print(mime_type)  # "text/markdown" (trusts the extension)
     >>>
     >>> # Create MIMEBlob from data
     >>> blob = km.create_mime_blob(jpeg_bytes)

--- a/packages/kiarina-utils-file/tests/mime/test_detect_mime_type.py
+++ b/packages/kiarina-utils-file/tests/mime/test_detect_mime_type.py
@@ -8,6 +8,8 @@ import kiarina.utils.mime as km
     "raw_data,file_name_hint,expected_mime_type",
     [
         (b"Hello, World!", "test.txt", "text/plain"),
+        (b"---\ntitle: hello\n---\ntest markdown", "test.md", "text/markdown"),  # Extension takes precedence
+        (None, "test.md", "text/markdown"),
         (b'{"key": "value"}', "config.json", "application/json"),
         (b"<html><body>Test</body></html>", "index.html", "text/html"),
         (b"\x89PNG\r\n\x1a\n", "image.png", "image/png"),
@@ -16,12 +18,12 @@ import kiarina.utils.mime as km
         (b"unknown content", "unknown.unknownext", None),
         (b"", "empty.txt", "text/plain"),
     ],
-    ids=[1, 2, 3, 4, 5, 6, 7, 8]
+    ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 )
 # fmt: on
 def test_detect_mime_type(raw_data, file_name_hint, expected_mime_type):
     result = km.detect_mime_type(
-        raw_data=raw_data,
         file_name_hint=file_name_hint,
+        raw_data=raw_data,
     )
     assert result == expected_mime_type

--- a/packages/kiarina/CHANGELOG.md
+++ b/packages/kiarina/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **kiarina-utils-file**: **BREAKING** - Changed MIME type detection strategy to prioritize file extensions over content analysis
 - **kiarina-utils-file**: Improved `detect_mime_type()` API with `MimeDetectionOptions` TypedDict to reduce cognitive load
 
 ### Fixed


### PR DESCRIPTION
## Summary

This PR introduces a **BREAKING CHANGE** to the MIME type detection strategy in `kiarina-utils-file`. The `detect_mime_type()` function now prioritizes file extension-based detection over content analysis.

## Philosophy

**File extensions represent explicit user intent and should be trusted.**

When a user names a file `document.md`, they are explicitly declaring it as a Markdown file. This intent should be respected, even if the content might look like plain text to a content analyzer.

## Changes

### Detection Strategy (BREAKING)

**Before (v1.1.0):**
1. Content analysis (puremagic) - prioritized
2. Custom dictionary lookup
3. Standard mimetypes library

**After (this PR):**
1. Extension-based detection (custom dictionary → mimetypes) - prioritized
2. Content analysis (puremagic) - fallback only

### API Changes (BREAKING)

**Function signature reordered:**

```python
# Before
detect_mime_type(
    raw_data=data,
    file_name_hint="document.md"
)

# After
detect_mime_type(
    file_name_hint="document.md",  # Now first parameter
    raw_data=data
)
```

### Behavior Changes

```python
# Example: .md file with plain text content
mime_type = detect_mime_type(
    file_name_hint="document.md",
    raw_data=b"Hello, World!"  # Looks like plain text
)

# Before: "text/plain" (content analysis wins)
# After:  "text/markdown" (extension wins)
```

## Rationale

### 1. **Intuitive Behavior**
- Users expect `.md` files to be treated as Markdown
- Applications should respect explicit file type declarations
- Content analysis should be a fallback, not the primary method

### 2. **Consistency with User Expectations**
- File managers, editors, and most tools prioritize extensions
- This aligns with common user mental models
- Reduces surprising behavior in applications

### 3. **Practical Use Cases**
- Markdown files often contain plain text that looks generic
- Configuration files (`.yaml`, `.toml`) may have simple content
- User intent (extension) is more reliable than heuristics

## Migration Guide

### For Most Users
No action needed if you're using file names with extensions. The behavior will be more intuitive.

### If You Relied on Content-Based Detection
If your code specifically relied on content analysis taking precedence:

```python
# Old behavior (content wins)
mime_type = detect_mime_type(
    raw_data=png_bytes,
    file_name_hint="document.md"
)
# Returned: "image/png"

# New behavior (extension wins)
mime_type = detect_mime_type(
    file_name_hint="document.md",
    raw_data=png_bytes
)
# Returns: "text/markdown"

# To get content-based detection, omit file_name_hint:
mime_type = detect_mime_type(raw_data=png_bytes)
# Returns: "image/png"
```

## Testing

- ✅ Added test for extension precedence behavior
- ✅ All existing tests pass with updated expectations
- ✅ Updated docstrings and module documentation
- ✅ CHANGELOG updated with migration notes

## Documentation Updates

- Updated `detect_mime_type()` docstring with new strategy
- Updated module-level documentation in `kiarina.utils.mime`
- Updated README.md with new examples
- Added philosophy section explaining the design decision

## Checklist

- [x] Code changes implemented
- [x] Tests added/updated
- [x] All tests passing
- [x] Documentation updated
- [x] CHANGELOG updated (root, meta package, sub package)
- [x] Breaking changes clearly documented

## Related Issues

This change improves the intuitiveness of MIME type detection and aligns with user expectations across the ecosystem.
