### PR TITLE
refactor(kiarina-lib-google-cloud-storage): separate authentication configuration from storage configuration

### DIFF
--- a/docs/knowledges/about_package_kiarina-lib-cloudflare-auth.md
+++ b/docs/knowledges/about_package_kiarina-lib-cloudflare-auth.md
@@ -6,3 +6,4 @@ description: >-
 ---
 
 kiarina-lib-cloudflare-auth provides a simple and secure way to manage Cloudflare authentication credentials using pydantic-settings-manager.
+This library enables the implementation of Cloudflare-related functionality by separating and managing authentication credentials from the application.

--- a/docs/knowledges/about_package_kiarina-lib-cloudflare-d1.md
+++ b/docs/knowledges/about_package_kiarina-lib-cloudflare-d1.md
@@ -1,0 +1,9 @@
+---
+title: About kiarina-lib-cloudflare-d1 package
+description: >-
+  kiarina-lib-cloudflare-d1 is a library for Cloudflare D1 database access
+  with configuration management using pydantic-settings-manager.
+---
+
+kiarina-lib-cloudflare-d1 is a thin wrapper library for using Cloudflare D1.
+The purpose of this library is to completely separate infrastructure settings such as authentication information and connection resource information from the application.

--- a/docs/knowledges/about_package_pydantic-settings-manager.md
+++ b/docs/knowledges/about_package_pydantic-settings-manager.md
@@ -3,6 +3,7 @@ title: README.md of pydantic-settings-manager
 description: >-
   In kiarina-python, settings are managed by pydantic-settings and pydantic-settings-manager.
   This file is a copy of the README.md from pydantic-settings-manager.
+  The creator of pydantic-settings-manager is kiarina.
 ---
 
 # pydantic-settings-manager

--- a/packages/kiarina-lib-google-cloud-storage/CHANGELOG.md
+++ b/packages/kiarina-lib-google-cloud-storage/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING**: Separated authentication configuration from storage configuration
+  - Removed `google_auth_config_key` field from `GoogleCloudStorageSettings`
+  - Added `auth_config_key` parameter to `get_storage_client()`, `get_bucket()`, and `get_blob()`
+  - Authentication is now configured separately through kiarina-lib-google-auth
+  - **Migration**: Replace `google_auth_config_key` in settings with `auth_config_key` parameter in function calls
+  - **Rationale**: Clear separation of concerns - storage settings define "where", authentication defines "who"
+  - **Benefits**: More flexible configuration, easier to reuse authentication across different storage configurations
+
 ## [1.5.0] - 2025-10-10
 
 ### Added

--- a/packages/kiarina-lib-google-cloud-storage/src/kiarina/lib/google/cloud_storage/_get_blob.py
+++ b/packages/kiarina-lib-google-cloud-storage/src/kiarina/lib/google/cloud_storage/_get_blob.py
@@ -7,7 +7,11 @@ from .settings import settings_manager
 
 
 def get_blob(
-    config_key: str | None = None, blob_name: str | None = None, **kwargs: Any
+    blob_name: str | None = None,
+    *,
+    config_key: str | None = None,
+    auth_config_key: str | None = None,
+    **kwargs: Any,
 ) -> storage.Blob:
     settings = settings_manager.get_settings_by_key(config_key)
 
@@ -20,5 +24,5 @@ def get_blob(
     if settings.blob_name_prefix:
         blob_name = f"{settings.blob_name_prefix}/{blob_name}"
 
-    bucket = get_bucket(config_key, **kwargs)
+    bucket = get_bucket(config_key, auth_config_key=auth_config_key, **kwargs)
     return bucket.blob(blob_name)

--- a/packages/kiarina-lib-google-cloud-storage/src/kiarina/lib/google/cloud_storage/_get_bucket.py
+++ b/packages/kiarina-lib-google-cloud-storage/src/kiarina/lib/google/cloud_storage/_get_bucket.py
@@ -6,11 +6,16 @@ from ._get_storage_client import get_storage_client
 from .settings import settings_manager
 
 
-def get_bucket(config_key: str | None = None, **kwargs: Any) -> storage.Bucket:
+def get_bucket(
+    config_key: str | None = None,
+    *,
+    auth_config_key: str | None = None,
+    **kwargs: Any,
+) -> storage.Bucket:
     settings = settings_manager.get_settings_by_key(config_key)
 
     if settings.bucket_name is None:
         raise ValueError("bucket_name is not set in the settings")
 
-    client = get_storage_client(config_key, **kwargs)
+    client = get_storage_client(auth_config_key, **kwargs)
     return client.bucket(settings.bucket_name)

--- a/packages/kiarina-lib-google-cloud-storage/src/kiarina/lib/google/cloud_storage/_get_storage_client.py
+++ b/packages/kiarina-lib-google-cloud-storage/src/kiarina/lib/google/cloud_storage/_get_storage_client.py
@@ -3,10 +3,10 @@ from typing import Any
 from google.cloud import storage  # type: ignore[import-untyped]
 from kiarina.lib.google.auth import get_credentials
 
-from .settings import settings_manager
 
-
-def get_storage_client(config_key: str | None = None, **kwargs: Any) -> storage.Client:
-    settings = settings_manager.get_settings_by_key(config_key)
-    credentials = get_credentials(settings.google_auth_config_key)
+def get_storage_client(
+    auth_config_key: str | None = None,
+    **kwargs: Any,
+) -> storage.Client:
+    credentials = get_credentials(auth_config_key)
     return storage.Client(credentials=credentials, **kwargs)

--- a/packages/kiarina-lib-google-cloud-storage/src/kiarina/lib/google/cloud_storage/settings.py
+++ b/packages/kiarina-lib-google-cloud-storage/src/kiarina/lib/google/cloud_storage/settings.py
@@ -3,8 +3,6 @@ from pydantic_settings_manager import SettingsManager
 
 
 class GoogleCloudStorageSettings(BaseSettings):
-    google_auth_config_key: str | None = None
-
     bucket_name: str | None = None
 
     blob_name_prefix: str | None = None

--- a/packages/kiarina-lib-google-cloud-storage/tests/test_get_blob.py
+++ b/packages/kiarina-lib-google-cloud-storage/tests/test_get_blob.py
@@ -9,7 +9,6 @@ def test_get_blob():
     # Setup settings
     settings_manager.user_config = {
         "default": {
-            "google_auth_config_key": "test_auth",
             "bucket_name": "test-bucket",
             "blob_name": "test-blob.txt",
         }
@@ -36,7 +35,6 @@ def test_get_blob_with_blob_name_parameter():
     # Setup settings
     settings_manager.user_config = {
         "default": {
-            "google_auth_config_key": "test_auth",
             "bucket_name": "test-bucket",
         }
     }
@@ -62,7 +60,6 @@ def test_get_blob_with_blob_name_prefix():
     # Setup settings with blob_name_prefix
     settings_manager.user_config = {
         "default": {
-            "google_auth_config_key": "test_auth",
             "bucket_name": "test-bucket",
             "blob_name_prefix": "prefix",
             "blob_name": "test-blob.txt",
@@ -90,7 +87,6 @@ def test_get_blob_with_blob_name_prefix_and_parameter():
     # Setup settings with blob_name_prefix
     settings_manager.user_config = {
         "default": {
-            "google_auth_config_key": "test_auth",
             "bucket_name": "test-bucket",
             "blob_name_prefix": "prefix",
         }
@@ -117,7 +113,6 @@ def test_get_blob_without_blob_name():
     # Setup settings without blob_name
     settings_manager.user_config = {
         "default": {
-            "google_auth_config_key": "test_auth",
             "bucket_name": "test-bucket",
         }
     }
@@ -132,7 +127,6 @@ def test_get_blob_with_custom_config_key():
     # Setup settings with custom config key
     settings_manager.user_config = {
         "custom": {
-            "google_auth_config_key": "custom_auth",
             "bucket_name": "custom-bucket",
             "blob_name": "custom-blob.txt",
         }
@@ -151,5 +145,31 @@ def test_get_blob_with_custom_config_key():
         blob = get_blob(config_key="custom")
         assert blob.name == "custom-blob.txt"
 
-        # Verify get_bucket was called with custom config key
-        mock_get_bucket.assert_called_once_with("custom")
+        # Verify get_bucket was called with custom config key and no auth_config_key
+        mock_get_bucket.assert_called_once_with("custom", auth_config_key=None)
+
+
+def test_get_blob_with_auth_config_key():
+    # Setup settings
+    settings_manager.user_config = {
+        "default": {
+            "bucket_name": "test-bucket",
+            "blob_name": "test-blob.txt",
+        }
+    }
+
+    # Mock get_bucket and blob
+    mock_bucket = MagicMock()
+    mock_blob = MagicMock()
+    mock_blob.name = "test-blob.txt"
+    mock_bucket.blob.return_value = mock_blob
+
+    with patch(
+        "kiarina.lib.google.cloud_storage._get_blob.get_bucket",
+        return_value=mock_bucket,
+    ) as mock_get_bucket:
+        blob = get_blob(auth_config_key="custom_auth")
+        assert blob.name == "test-blob.txt"
+
+        # Verify get_bucket was called with custom auth config key
+        mock_get_bucket.assert_called_once_with(None, auth_config_key="custom_auth")

--- a/packages/kiarina-lib-google-cloud-storage/tests/test_get_bucket.py
+++ b/packages/kiarina-lib-google-cloud-storage/tests/test_get_bucket.py
@@ -9,7 +9,6 @@ def test_get_bucket():
     # Setup settings
     settings_manager.user_config = {
         "default": {
-            "google_auth_config_key": "test_auth",
             "bucket_name": "test-bucket",
         }
     }
@@ -23,9 +22,12 @@ def test_get_bucket():
     with patch(
         "kiarina.lib.google.cloud_storage._get_bucket.get_storage_client",
         return_value=mock_client,
-    ):
+    ) as mock_get_client:
         bucket = get_bucket()
         assert bucket.name == "test-bucket"
+
+        # Verify get_storage_client was called with None (default)
+        mock_get_client.assert_called_once_with(None)
 
         # Verify bucket was called with correct bucket name
         mock_client.bucket.assert_called_once_with("test-bucket")
@@ -33,11 +35,7 @@ def test_get_bucket():
 
 def test_get_bucket_without_bucket_name():
     # Setup settings without bucket_name
-    settings_manager.user_config = {
-        "default": {
-            "google_auth_config_key": "test_auth",
-        }
-    }
+    settings_manager.user_config = {"default": {}}
 
     with pytest.raises(ValueError, match="bucket_name is not set in the settings"):
         get_bucket()
@@ -47,7 +45,6 @@ def test_get_bucket_with_custom_config_key():
     # Setup settings with custom config key
     settings_manager.user_config = {
         "custom": {
-            "google_auth_config_key": "custom_auth",
             "bucket_name": "custom-bucket",
         }
     }
@@ -65,5 +62,30 @@ def test_get_bucket_with_custom_config_key():
         bucket = get_bucket(config_key="custom")
         assert bucket.name == "custom-bucket"
 
-        # Verify get_storage_client was called with custom config key
-        mock_get_client.assert_called_once_with("custom")
+        # Verify get_storage_client was called with None (no auth_config_key specified)
+        mock_get_client.assert_called_once_with(None)
+
+
+def test_get_bucket_with_auth_config_key():
+    # Setup settings
+    settings_manager.user_config = {
+        "default": {
+            "bucket_name": "test-bucket",
+        }
+    }
+
+    # Mock get_storage_client and bucket
+    mock_client = MagicMock()
+    mock_bucket = MagicMock()
+    mock_bucket.name = "test-bucket"
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch(
+        "kiarina.lib.google.cloud_storage._get_bucket.get_storage_client",
+        return_value=mock_client,
+    ) as mock_get_client:
+        bucket = get_bucket(auth_config_key="custom_auth")
+        assert bucket.name == "test-bucket"
+
+        # Verify get_storage_client was called with custom auth config key
+        mock_get_client.assert_called_once_with("custom_auth")

--- a/packages/kiarina-lib-google-cloud-storage/tests/test_get_storage_client.py
+++ b/packages/kiarina-lib-google-cloud-storage/tests/test_get_storage_client.py
@@ -1,16 +1,9 @@
 from unittest.mock import MagicMock, patch
 
-from kiarina.lib.google.cloud_storage import get_storage_client, settings_manager
+from kiarina.lib.google.cloud_storage import get_storage_client
 
 
 def test_get_storage_client():
-    # Setup settings
-    settings_manager.user_config = {
-        "default": {
-            "google_auth_config_key": "test_auth",
-        }
-    }
-
     # Mock get_credentials and storage.Client
     mock_credentials = MagicMock()
     mock_credentials.project_id = "test-project"
@@ -21,7 +14,7 @@ def test_get_storage_client():
         patch(
             "kiarina.lib.google.cloud_storage._get_storage_client.get_credentials",
             return_value=mock_credentials,
-        ),
+        ) as mock_get_credentials,
         patch(
             "kiarina.lib.google.cloud_storage._get_storage_client.storage.Client",
             return_value=mock_client,
@@ -29,6 +22,36 @@ def test_get_storage_client():
     ):
         client = get_storage_client()
         assert client.project == "test-project"
+
+        # Verify get_credentials was called with None (default)
+        mock_get_credentials.assert_called_once_with(None)
+
+        # Verify Client was called with correct credentials
+        mock_client_class.assert_called_once_with(credentials=mock_credentials)
+
+
+def test_get_storage_client_with_auth_config_key():
+    # Mock get_credentials and storage.Client
+    mock_credentials = MagicMock()
+    mock_credentials.project_id = "custom-project"
+    mock_client = MagicMock()
+    mock_client.project = "custom-project"
+
+    with (
+        patch(
+            "kiarina.lib.google.cloud_storage._get_storage_client.get_credentials",
+            return_value=mock_credentials,
+        ) as mock_get_credentials,
+        patch(
+            "kiarina.lib.google.cloud_storage._get_storage_client.storage.Client",
+            return_value=mock_client,
+        ) as mock_client_class,
+    ):
+        client = get_storage_client(auth_config_key="custom_auth")
+        assert client.project == "custom-project"
+
+        # Verify get_credentials was called with custom auth config key
+        mock_get_credentials.assert_called_once_with("custom_auth")
 
         # Verify Client was called with correct credentials
         mock_client_class.assert_called_once_with(credentials=mock_credentials)


### PR DESCRIPTION
## Summary

This PR refactors the kiarina-lib-google-cloud-storage package to separate authentication configuration from storage configuration, providing clearer separation of concerns and more flexible configuration options.

## Changes

### Breaking Changes

- **Removed** `google_auth_config_key` field from `GoogleCloudStorageSettings`
- **Added** `auth_config_key` parameter to `get_storage_client()`, `get_bucket()`, and `get_blob()` functions

### Migration Guide

**Before:**
```python
settings_manager.user_config = {
    "default": {
        "google_auth_config_key": "production",
        "bucket_name": "my-bucket"
    }
}
bucket = get_bucket()
```

**After:**
```python
settings_manager.user_config = {
    "default": {
        "bucket_name": "my-bucket"
    }
}
bucket = get_bucket(auth_config_key="production")
```

### Rationale

- **Clear separation of concerns**: Storage settings define "where" (bucket, prefix), authentication defines "who" (credentials)
- **More flexible configuration**: Same authentication can be used with multiple storage configurations, and vice versa
- **Easier to reuse**: Authentication configuration can be shared across different storage configurations
- **Consistent with design philosophy**: Follows the infrastructure-application separation principle

### Updated Files

- `packages/kiarina-lib-google-cloud-storage/CHANGELOG.md`: Added breaking change documentation
- `packages/kiarina-lib-google-cloud-storage/README.md`: Updated documentation with new API and examples
- `packages/kiarina-lib-google-cloud-storage/src/kiarina/lib/google/cloud_storage/settings.py`: Removed `google_auth_config_key` field
- `packages/kiarina-lib-google-cloud-storage/src/kiarina/lib/google/cloud_storage/_get_storage_client.py`: Changed to accept `auth_config_key` parameter
- `packages/kiarina-lib-google-cloud-storage/src/kiarina/lib/google/cloud_storage/_get_bucket.py`: Added `auth_config_key` parameter
- `packages/kiarina-lib-google-cloud-storage/src/kiarina/lib/google/cloud_storage/_get_blob.py`: Added `auth_config_key` parameter
- Test files: Updated all tests to reflect the new API

### Documentation Updates

- Added knowledge base entries for related packages
- Updated README with comprehensive examples showing the new separation pattern
- Added migration guide in CHANGELOG

## Testing

All tests have been updated and pass successfully:
- ✅ Unit tests for `get_storage_client()`
- ✅ Unit tests for `get_bucket()`
- ✅ Unit tests for `get_blob()`
- ✅ Tests for custom `auth_config_key` parameter

## Benefits

1. **Flexibility**: Mix and match authentication and storage configurations
2. **Clarity**: Clear distinction between authentication (who) and storage (where)
3. **Reusability**: Share authentication across different storage configurations
4. **Consistency**: Aligns with the design philosophy of infrastructure-application separation

## Example Use Cases

### Multi-tenant with shared authentication
```python
# One authentication, multiple storage configurations
bucket1 = get_bucket(config_key="tenant_a", auth_config_key="shared_auth")
bucket2 = get_bucket(config_key="tenant_b", auth_config_key="shared_auth")
```

### Multiple authentications with same storage
```python
# Different credentials for same bucket (e.g., read-only vs read-write)
bucket_ro = get_bucket(config_key="default", auth_config_key="readonly_auth")
bucket_rw = get_bucket(config_key="default", auth_config_key="readwrite_auth")
```